### PR TITLE
fix wrong interpretation of multi get result of jedis

### DIFF
--- a/src/main/java/com/qubole/utility/RedisCache.java
+++ b/src/main/java/com/qubole/utility/RedisCache.java
@@ -186,7 +186,8 @@ public class RedisCache<K, V> extends AbstractLoadingCache<K, V> implements Load
 
       Map<K, V> map = new LinkedHashMap<>();
       int i = 0;
-      // mget always return an array of keys size. Each entry would correspond the key of that index.
+      // mget always return an array of keys size.
+      // Each entry would correspond the key of that index.
       // if no such key exists vaue will be null.
 
       for (Object key : keys) {

--- a/src/main/java/com/qubole/utility/RedisCache.java
+++ b/src/main/java/com/qubole/utility/RedisCache.java
@@ -184,17 +184,18 @@ public class RedisCache<K, V> extends AbstractLoadingCache<K, V> implements Load
     try (Jedis jedis = jedisPool.getResource()) {
       List<byte[]> valueBytes = jedis.mget(Iterables.toArray(keyBytes, byte[].class));
 
-      // check for null entry
-      if (valueBytes.size() == 1 && valueBytes.get(0) == null) {
-        return ImmutableMap.of();
-      }
       Map<K, V> map = new LinkedHashMap<>();
       int i = 0;
+      // mget always return an array of keys size. Each entry would correspond the key of that index.
+      // if no such key exists vaue will be null.
+
       for (Object key : keys) {
-        @SuppressWarnings("unchecked")
-        K castKey = (K) key;
-        map.put(castKey, valueSerializer.<V>deserialize(valueBytes.get(i)));
-        i++;
+        if (valueBytes.get(i) != null) {
+          @SuppressWarnings("unchecked")
+          K castKey = (K) key;
+          map.put(castKey, valueSerializer.<V>deserialize(valueBytes.get(i)));
+          i++;
+        }
       }
       return ImmutableMap.copyOf(map);
     }


### PR DESCRIPTION
Presto UTs have caught this bug (https://bitbucket.org/qubole/presto/src/024609568295fcf5c77461980b0f060923fbe157/qubole-presto-hive/src/test/java/com/qubole/arya/TestCachingDirectMetaStoreClient.java?fileviewer=file-view-default#testGetPartitionsByNames?at=q-presto-0.180)